### PR TITLE
Make the header be sticky

### DIFF
--- a/src/app/post-security/page.tsx
+++ b/src/app/post-security/page.tsx
@@ -32,7 +32,7 @@ export default function Page() {
     <main className="min-h-screen flex flex-col">
       <SidebarProvider>
         <PostSecuritySidebar />
-        <SidebarInset className="flex flex-col min-h-screen">
+        <SidebarInset className="flex flex-col">
           <header className="sticky top-0 z-50 flex h-12 shrink-0 items-center gap-2 px-4 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
             <SidebarTrigger aria-label="Open sidebar" className="-ml-1" />
             <Separator
@@ -70,11 +70,11 @@ export default function Page() {
                   >
                     <a
                       href={`#${anchorId}`}
-                      aria-label={`Link to ${name}`}
                       className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                     >
                       <h2
                         id={anchorId}
+                        tabIndex={-1}
                         className="flex items-center gap-2 text-[var(--primary)]"
                       >
                         {name}

--- a/src/app/post-security/sidebar.tsx
+++ b/src/app/post-security/sidebar.tsx
@@ -100,7 +100,7 @@ export function PostSecuritySidebar({
                       className="font-medium"
                       onClick={handleMenuItemClick}
                       aria-current={
-                        hash === `#${anchorId}` ? "page" : undefined
+                        hash === `#${anchorId}` ? "location" : undefined
                       }
                     >
                       {name}


### PR DESCRIPTION
Fixes #4 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Region headings are now linkable anchors for easier navigation and sharing.
  * Mobile sidebar automatically closes when a menu item is selected.

* **Style**
  * App layout updated to a full-viewport, columnar structure for more consistent spacing.
  * Header is now sticky with reduced height, subtle blur and border for improved clarity.
  * Content area restructured with refined padding while preserving existing grid and widths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->