### PR TITLE
Move the plane tail clue to a gates

### DIFF
--- a/src/data/post-security-clues.ts
+++ b/src/data/post-security-clues.ts
@@ -32,7 +32,7 @@ export const postSecurityClues: ReadonlyArray<Clue> = [
   {
     id: "BL5xfCD1Pl", // cspell: disable-line
     clue: "Take a photo of three different aircraft tails for non-US carriers.",
-    airportArea: AirportArea.CONCOURSE_B,
+    airportArea: AirportArea.CONCOURSE_A,
     answerType: AnswerType.IMAGE,
     clueType: ClueType.TEXT,
     // answer: "",


### PR DESCRIPTION
Fixes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the concourse assignment for a post-security clue; it now appears under Concourse A instead of Concourse B.
  * Improves accuracy of in-app listings, maps, and filters for that clue to aid navigation.
  * No other clues or user-facing features were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->