### PR TITLE
Add fire extinguisher question, update sculpture question

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -51,8 +51,9 @@
       "hint": "Airport flow is the direction airplanes take off toward. For example, if planes take off toward the south, the airport is in south flow."
     },
     "JTaK-wv-cm": {
-      "answer": "10 (to be verified)",
-      "clue": "How many balls are in the sculpture?"
+      "answer": "14",
+      "answerDetails": "There are 13 balls in the north section of the sculpture, and one ball in the south section.",
+      "clue": "Find \"On: Matter, monkeys and the king\" by Trimpin. How many balls are in the sculpture?"
     },
     "JjwwVsnaNJ": {
       "answerDetails": "The vending machines near the escalators in the South Satellite sell a variety of Japanese food and drinks.",
@@ -137,6 +138,10 @@
     },
     "qsWmZtJQx9": {
       "clue": "Search the gate screens and snap a photo of the highest flight number you spot."
+    },
+    "qtcTszICZ5": {
+      "answer": "12",
+      "clue": "Ride the yellow line train. How many fire extinguishers are mounted to the wall in the tunnel?"
     },
     "sZLbWTNUXK": {
       "clue": "Take a photo of a sign written in a language other than English."

--- a/messages/en.json
+++ b/messages/en.json
@@ -141,7 +141,8 @@
     },
     "qtcTszICZ5": {
       "answer": "12",
-      "clue": "Ride the yellow line train. How many fire extinguishers are mounted to the wall in the tunnel?"
+      "clue": "Ride the yellow line train. How many fire extinguishers are mounted to the wall in the tunnel?",
+      "hint": "Count only extinguishers mounted to the tunnel wall; the one on the train does not count."
     },
     "sZLbWTNUXK": {
       "clue": "Take a photo of a sign written in a language other than English."

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -51,8 +51,9 @@
       "hint": "Le flux d'aéroport est la direction vers laquelle les avions décollent. Par exemple, si les avions décollent vers le sud, l'aéroport est en flux sud."
     },
     "JTaK-wv-cm": {
-      "answer": "10 (à vérifier)",
-      "clue": "Combien de balles y a-t-il dans la sculpture ?"
+      "answer": "14",
+      "answerDetails": "Il y a 13 balles dans la section nord de la sculpture, et une balle dans la section sud.",
+      "clue": "Trouvez \"On: Matter, monkeys and the king\" de Trimpin. Combien de balles y a-t-il dans la sculpture ?"
     },
     "JjwwVsnaNJ": {
       "answerDetails": "Les distributeurs automatiques près des escalators dans le Satellite Sud vendent une variété de nourriture et boissons japonaises.",
@@ -137,6 +138,10 @@
     },
     "qsWmZtJQx9": {
       "clue": "Cherchez dans les écrans des portes et prenez une photo du numéro de vol le plus élevé que vous repérez."
+    },
+    "qtcTszICZ5": {
+      "answer": "12",
+      "clue": "Prenez la ligne de train jaune. Combien d'extincteurs sont fixés au mur dans le tunnel ?"
     },
     "sZLbWTNUXK": {
       "clue": "Prenez une photo d'un panneau écrit dans une langue autre que l'anglais."

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -141,7 +141,8 @@
     },
     "qtcTszICZ5": {
       "answer": "12",
-      "clue": "Prenez la ligne de train jaune. Combien d'extincteurs sont fixés au mur dans le tunnel ?"
+      "clue": "Prenez la ligne de train jaune. Combien d'extincteurs sont fixés au mur dans le tunnel ?",
+      "hint": "Comptez uniquement les extincteurs fixés au mur du tunnel; celui dans le train ne compte pas."
     },
     "sZLbWTNUXK": {
       "clue": "Prenez une photo d'un panneau écrit dans une langue autre que l'anglais."

--- a/src/data/post-security-clues.ts
+++ b/src/data/post-security-clues.ts
@@ -277,4 +277,10 @@ export const postSecurityClues: ReadonlyArray<Clue> = [
     answerType: AnswerType.IMAGE,
     clueType: ClueType.TEXT,
   },
+  {
+    id: "qtcTszICZ5", // cspell: disable-line
+    airportArea: AirportArea.CONCOURSE_D,
+    answerType: AnswerType.TEXT,
+    clueType: ClueType.TEXT,
+  },
 ];


### PR DESCRIPTION
Fixes #34
Fixes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new post-security clue about counting fire extinguishers along the yellow line tunnel, available in English and French.

- Bug Fixes
  - Corrected the answer for the Trimpin sculpture clue to 14 and clarified details (13 balls in the north section, 1 in the south), with updated wording in English and French for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->