### PR TITLE
Switch to radio group for language switcher

### DIFF
--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -46,13 +46,19 @@ export default function LanguageSwitcher({
 
   const switchLocale = useCallback(
     (nextLocale: string) => {
+      // Guard against unexpected values
+      if (!languages.some((l) => l.code === nextLocale)) {
+        console.warn("Unknown locale:", nextLocale);
+        return;
+      }
+
       startTransition(() => {
         router.replace(
           // @ts-expect-error -- TypeScript will validate that only known `params`
           // are used in combination with a given `pathname`. Since the two will
           // always match for the current route, we can skip runtime checks.
           { pathname, params: parameters },
-          { locale: nextLocale },
+          { locale: nextLocale as Locale },
         );
       });
     },
@@ -95,13 +101,10 @@ export default function LanguageSwitcher({
         <DropdownMenuContent align="end" className="min-w-[150px]">
           <DropdownMenuRadioGroup value={locale} onValueChange={switchLocale}>
             {languages.map((language) => {
-              const selected = currentLanguage.code === language.code;
-
               return (
                 <DropdownMenuRadioItem
                   value={language.code}
                   key={language.code}
-                  className={`cursor-pointer ${selected ? "bg-accent text-accent-foreground" : ""}`}
                 >
                   <language.flagComponent
                     className="w-4 h-3 mr-2"

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -128,16 +128,11 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[state=checked]:bg-accent data-[state=checked]:text-accent-foreground",
         className
       )}
       {...props}
     >
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <CircleIcon className="size-2 fill-current" />
-        </DropdownMenuPrimitive.ItemIndicator>
-      </span>
       {children}
     </DropdownMenuPrimitive.RadioItem>
   )


### PR DESCRIPTION
Fixes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the language selector to a single-choice radio-style menu for clearer indication of the current language.
  * Improved accessibility using native radio-group semantics and better screen reader support.
  * Streamlined keyboard navigation and selection within the menu.
  * Maintains smooth language-switch transitions and now ignores invalid/unknown language selections gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->