### PR TITLE
Remove image upload/mobile test

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -5,8 +5,7 @@
     },
     "image-answer": {
       "choose-files-button": "{expectedImageCount, plural, =1 {Datei auswählen} other {Dateien auswählen}}",
-      "remove-image-aria": "Bild {index, number} entfernen",
-      "take-photo-button": "Foto aufnehmen"
+      "remove-image-aria": "Bild {index, number} entfernen"
     },
     "language-switcher": {
       "de": "Deutsch",
@@ -206,6 +205,12 @@
         },
         "clue": "Wo arbeitet Cordell \"The Transformer\" Truluck?"
       },
+      "fyptkfnu62": {
+        "answer": {
+          "details": "Gegrillte Käse-Sandwiches sind verfügbar bei:\n\n* Village Pub\n* Skillet\n* Beecher's Handmade Cheese\n* SkyGamerz"
+        },
+        "clue": "Finden Sie zwei Restaurants, wo Sie ein gegrilltes Käse-Sandwich kaufen können."
+      },
       "glwn2opFlc": {
         "answer": {
           "answer": "Skillet, in der Nähe von Gate C10."
@@ -233,38 +238,19 @@
       "ndC0lIJES6": {
         "clue": "Machen Sie ein Foto von einer Hibiskusblüte."
       },
-      "fyptkfnu62": {
-        "answer": {
-          "details": "Gegrillte Käse-Sandwiches sind verfügbar bei:\n\n* Village Pub\n* Skillet\n* Beecher's Handmade Cheese\n* SkyGamerz"
-        },
-        "clue": "Finden Sie zwei Restaurants, wo Sie ein gegrilltes Käse-Sandwich kaufen können."
-      },
-      "x7mtgkrj6s": {
-        "answer": {
-          "answer": "Bronze",
-          "details": "[\"Blackleaf\"](https://www.portseattle.org/page/blackleaf-deborah-butterfield) ist sieben Fuß hoch und ist Teil von Butterfields Sammlung von Bronzeguss-Werken und stellt ein stehendes Pferd dar."
-        },
-        "clue": "Finden Sie die \"Blackleaf\"-Statue von Deborah Butterfield. Woraus ist sie gemacht?"
-      },
-      "pngb9scdvn": {
-        "answer": {
-          "answer": "Im Restaurant Lil' Woody's."
-        },
-        "clue": "Wo können Sie dieses Fliesenmuster finden?",
-        "alternateText": "Ein dekoratives Fliesenmuster mit geometrischen Designs"
-      },
-      "tqvatszvgw": {
-        "answer": {
-          "answer": "Bei SEA Pop Culture, Pike and Pine und chalo&co"
-        },
-        "clue": "Wo können Sie ein Stofftier kaufen?"
-      },
       "pB53_yVOPQ": {
         "answer": {
           "details": "Die Lounges sind:\n\n* Delta (A11)\n* Delta One (A11)\n* The Club (A11)\n* United (A10)\n* Delta (A1)\n* American Express Centurion (Zentrales Terminal)\n* Alaska (C16)\n* Alaska (D1)\n* Alaska (Mezzanin über N13-N18)\n* The Club (über S10)\n* British Airways (über S10)."
         },
         "clue": "Machen Sie ein Foto vor dem Eingang jeder Flughafen-Lounge.",
         "hint": "Es gibt elf Lounges am SEA mit zehn Eingängen."
+      },
+      "pngb9scdvn": {
+        "alternateText": "Ein dekoratives Fliesenmuster mit geometrischen Designs",
+        "answer": {
+          "answer": "Im Restaurant Lil' Woody's."
+        },
+        "clue": "Wo können Sie dieses Fliesenmuster finden?"
       },
       "qsWmZtJQx9": {
         "clue": "Durchsuchen Sie die Gate-Bildschirme und machen Sie ein Foto von der höchsten Flugnummer, die Sie entdecken."
@@ -284,6 +270,12 @@
           "answer": "Japan Airlines (JAL) und Qatar Airways"
         },
         "clue": "Welche Fluggesellschaften gewähren Business-Class-Passagieren Zugang zu sowohl The Club als auch British Airways Terraces Lounges?"
+      },
+      "tqvatszvgw": {
+        "answer": {
+          "answer": "Bei SEA Pop Culture, Pike and Pine und chalo&co"
+        },
+        "clue": "Wo können Sie ein Stofftier kaufen?"
       },
       "uaPC_HvMqd": {
         "clue": "Machen Sie ein Foto von etwas mit der Space Needle darauf."
@@ -321,6 +313,13 @@
           "answer": "+1-800-TBD-9999 (zu überprüfen)"
         },
         "clue": "Finden Sie das CBP-Büro in Flugsteig A. Welche Telefonnummer steht draußen angeschlagen?"
+      },
+      "x7mtgkrj6s": {
+        "answer": {
+          "answer": "Bronze",
+          "details": "[\"Blackleaf\"](https://www.portseattle.org/page/blackleaf-deborah-butterfield) ist sieben Fuß hoch und ist Teil von Butterfields Sammlung von Bronzeguss-Werken und stellt ein stehendes Pferd dar."
+        },
+        "clue": "Finden Sie die \"Blackleaf\"-Statue von Deborah Butterfield. Woraus ist sie gemacht?"
       },
       "xH4xrNHYJe": {
         "answer": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,8 +5,7 @@
     },
     "image-answer": {
       "choose-files-button": "Choose {expectedImageCount, plural, =1 {file} other {files}}",
-      "remove-image-aria": "Remove image {index, number}",
-      "take-photo-button": "Take a photo"
+      "remove-image-aria": "Remove image {index, number}"
     },
     "language-switcher": {
       "de": "Deutsch",
@@ -208,6 +207,12 @@
         },
         "clue": "Where does Cordell \"The Transformer\" Truluck work?"
       },
+      "fyptkfnu62": {
+        "answer": {
+          "details": "Grilled cheese sandwiches are available at:\n\n* Village Pub\n* Skillet\n* Beecher's Handmade Cheese\n* SkyGamerz"
+        },
+        "clue": "Find two restaurants where you can buy a grilled cheese sandwich."
+      },
       "glwn2opFlc": {
         "answer": {
           "answer": "Skillet, near gate C10."
@@ -235,38 +240,19 @@
       "ndC0lIJES6": {
         "clue": "Take a photo of a hibiscus flower."
       },
-      "fyptkfnu62": {
-        "answer": {
-          "details": "Grilled cheese sandwiches are available at:\n\n* Village Pub\n* Skillet\n* Beecher's Handmade Cheese\n* SkyGamerz"
-        },
-        "clue": "Find two restaurants where you can buy a grilled cheese sandwich."
-      },
-      "x7mtgkrj6s": {
-        "answer": {
-          "answer": "Bronze",
-          "details": "[\"Blackleaf\"](https://www.portseattle.org/page/blackleaf-deborah-butterfield) is seven feet tall, and is a part of Butterfield's bronze cast collection of works and represents a standing horse."
-        },
-        "clue": "Find the \"Blackleaf\" statue by Deborah Butterfield. What is it made of?"
-      },
-      "pngb9scdvn": {
-        "answer": {
-          "answer": "At Lil' Woody's restaurant."
-        },
-        "clue": "Where can you find this tile pattern?",
-        "alternateText": "A decorative tile pattern with geometric designs"
-      },
-      "tqvatszvgw": {
-        "answer": {
-          "answer": "At SEA Pop Culture, Pike and Pine, and chalo&co"
-        },
-        "clue": "Where can you buy a stuffed animal?"
-      },
       "pB53_yVOPQ": {
         "answer": {
           "details": "The lounges are:\n\n* Delta (A11)\n* Delta One (A11)\n* The Club (A11)\n* United (A10)\n* Delta (A1)\n* American Express Centurion (Central Terminal)\n* Alaska (C16)\n* Alaska (D1)\n* Alaska (mezzanine above N13-N18)\n* The Club (above S10)\n* British Airways (above S10)."
         },
         "clue": "Take a photo outside the entrance of each airport lounge.",
         "hint": "There are eleven lounges at SEA, with ten entrances."
+      },
+      "pngb9scdvn": {
+        "alternateText": "A decorative tile pattern with geometric designs",
+        "answer": {
+          "answer": "At Lil' Woody's restaurant."
+        },
+        "clue": "Where can you find this tile pattern?"
       },
       "qsWmZtJQx9": {
         "clue": "Search the gate screens and snap a photo of the highest flight number you spot."
@@ -286,6 +272,12 @@
           "answer": "Japan Airlines (JAL) and Qatar Airways"
         },
         "clue": "Which airlines grant business class passengers access to both The Club and British Airways Terraces lounges?"
+      },
+      "tqvatszvgw": {
+        "answer": {
+          "answer": "At SEA Pop Culture, Pike and Pine, and chalo&co"
+        },
+        "clue": "Where can you buy a stuffed animal?"
       },
       "uaPC_HvMqd": {
         "clue": "Take a photo of something with the Space Needle on it."
@@ -323,6 +315,13 @@
           "answer": "+1-800-TBD-9999 (to be verified)"
         },
         "clue": "Find the CBP office in Concourse A. What's the phone number posted outside?"
+      },
+      "x7mtgkrj6s": {
+        "answer": {
+          "answer": "Bronze",
+          "details": "[\"Blackleaf\"](https://www.portseattle.org/page/blackleaf-deborah-butterfield) is seven feet tall, and is a part of Butterfield's bronze cast collection of works and represents a standing horse."
+        },
+        "clue": "Find the \"Blackleaf\" statue by Deborah Butterfield. What is it made of?"
       },
       "xH4xrNHYJe": {
         "answer": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -5,8 +5,7 @@
     },
     "image-answer": {
       "choose-files-button": "Elegir {expectedImageCount, plural, =1 {archivo} other {archivos}}",
-      "remove-image-aria": "Eliminar imagen {index, number}",
-      "take-photo-button": "Tomar una foto"
+      "remove-image-aria": "Eliminar imagen {index, number}"
     },
     "language-switcher": {
       "de": "Deutsch",
@@ -206,6 +205,12 @@
         },
         "clue": "¿Dónde trabaja Cordell \"The Transformer\" Truluck?"
       },
+      "fyptkfnu62": {
+        "answer": {
+          "details": "Los sándwiches de queso a la plancha están disponibles en:\n\n* Village Pub\n* Skillet\n* Beecher's Handmade Cheese\n* SkyGamerz"
+        },
+        "clue": "Encuentre dos restaurantes donde pueda comprar un sándwich de queso a la plancha."
+      },
       "glwn2opFlc": {
         "answer": {
           "answer": "Skillet, cerca de la puerta C10."
@@ -233,38 +238,19 @@
       "ndC0lIJES6": {
         "clue": "Tome una foto de una flor de hibisco."
       },
-      "fyptkfnu62": {
-        "answer": {
-          "details": "Los sándwiches de queso a la plancha están disponibles en:\n\n* Village Pub\n* Skillet\n* Beecher's Handmade Cheese\n* SkyGamerz"
-        },
-        "clue": "Encuentre dos restaurantes donde pueda comprar un sándwich de queso a la plancha."
-      },
-      "x7mtgkrj6s": {
-        "answer": {
-          "answer": "Bronce",
-          "details": "[\"Blackleaf\"](https://www.portseattle.org/page/blackleaf-deborah-butterfield) mide siete pies de altura y es parte de la colección de obras de bronce fundido de Butterfield y representa un caballo de pie."
-        },
-        "clue": "Encuentre la estatua \"Blackleaf\" de Deborah Butterfield. ¿De qué está hecha?"
-      },
-      "pngb9scdvn": {
-        "answer": {
-          "answer": "En el restaurante Lil' Woody's."
-        },
-        "clue": "¿Dónde puede encontrar este patrón de azulejos?",
-        "alternateText": "Un patrón de azulejos decorativo con diseños geométricos"
-      },
-      "tqvatszvgw": {
-        "answer": {
-          "answer": "En SEA Pop Culture, Pike and Pine, y chalo&co"
-        },
-        "clue": "¿Dónde puede comprar un animal de peluche?"
-      },
       "pB53_yVOPQ": {
         "answer": {
           "details": "Las salas VIP son:\n\n* Delta (A11)\n* Delta One (A11)\n* The Club (A11)\n* United (A10)\n* Delta (A1)\n* American Express Centurion (Terminal Central)\n* Alaska (C16)\n* Alaska (D1)\n* Alaska (entreplanta sobre N13-N18)\n* The Club (sobre S10)\n* British Airways (sobre S10)."
         },
         "clue": "Tome una foto fuera de la entrada de cada sala VIP del aeropuerto.",
         "hint": "Hay once salas VIP en SEA, con diez entradas."
+      },
+      "pngb9scdvn": {
+        "alternateText": "Un patrón de azulejos decorativo con diseños geométricos",
+        "answer": {
+          "answer": "En el restaurante Lil' Woody's."
+        },
+        "clue": "¿Dónde puede encontrar este patrón de azulejos?"
       },
       "qsWmZtJQx9": {
         "clue": "Busque en las pantallas de las puertas y tome una foto del número de vuelo más alto que encuentre."
@@ -284,6 +270,12 @@
           "answer": "Japan Airlines (JAL) y Qatar Airways"
         },
         "clue": "¿Qué aerolíneas otorgan acceso a los pasajeros de clase ejecutiva tanto a The Club como a las salas British Airways Terraces?"
+      },
+      "tqvatszvgw": {
+        "answer": {
+          "answer": "En SEA Pop Culture, Pike and Pine, y chalo&co"
+        },
+        "clue": "¿Dónde puede comprar un animal de peluche?"
       },
       "uaPC_HvMqd": {
         "clue": "Tome una foto de algo que tenga la Space Needle en él."
@@ -321,6 +313,13 @@
           "answer": "+1-800-TBD-9999 (por verificar)"
         },
         "clue": "Encuentre la oficina de CBP en el Vestíbulo A. ¿Cuál es el número de teléfono publicado afuera?"
+      },
+      "x7mtgkrj6s": {
+        "answer": {
+          "answer": "Bronce",
+          "details": "[\"Blackleaf\"](https://www.portseattle.org/page/blackleaf-deborah-butterfield) mide siete pies de altura y es parte de la colección de obras de bronce fundido de Butterfield y representa un caballo de pie."
+        },
+        "clue": "Encuentre la estatua \"Blackleaf\" de Deborah Butterfield. ¿De qué está hecha?"
       },
       "xH4xrNHYJe": {
         "answer": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -5,8 +5,7 @@
     },
     "image-answer": {
       "choose-files-button": "Choisir {expectedImageCount, plural, =1 {le fichier} other {des fichiers}}",
-      "remove-image-aria": "Supprimer l'image {index, number}",
-      "take-photo-button": "Prendre une photo"
+      "remove-image-aria": "Supprimer l'image {index, number}"
     },
     "language-switcher": {
       "de": "Deutsch",
@@ -206,6 +205,12 @@
         },
         "clue": "Où travaille Cordell \"The Transformer\" Truluck ?"
       },
+      "fyptkfnu62": {
+        "answer": {
+          "details": "Les sandwichs au fromage grillé sont disponibles à :\n\n* Village Pub\n* Skillet\n* Beecher's Handmade Cheese\n* SkyGamerz"
+        },
+        "clue": "Trouvez deux restaurants où vous pouvez acheter un sandwich au fromage grillé."
+      },
       "glwn2opFlc": {
         "answer": {
           "answer": "Skillet, près de la porte C10."
@@ -233,38 +238,19 @@
       "ndC0lIJES6": {
         "clue": "Prenez une photo d'une fleur d'hibiscus."
       },
-      "fyptkfnu62": {
-        "answer": {
-          "details": "Les sandwichs au fromage grillé sont disponibles à :\n\n* Village Pub\n* Skillet\n* Beecher's Handmade Cheese\n* SkyGamerz"
-        },
-        "clue": "Trouvez deux restaurants où vous pouvez acheter un sandwich au fromage grillé."
-      },
-      "x7mtgkrj6s": {
-        "answer": {
-          "answer": "Bronze",
-          "details": "[\"Blackleaf\"](https://www.portseattle.org/page/blackleaf-deborah-butterfield) mesure sept pieds de haut et fait partie de la collection d'œuvres en bronze coulé de Butterfield et représente un cheval debout."
-        },
-        "clue": "Trouvez la statue \"Blackleaf\" de Deborah Butterfield. De quoi est-elle faite ?"
-      },
-      "pngb9scdvn": {
-        "answer": {
-          "answer": "Au restaurant Lil' Woody's."
-        },
-        "clue": "Où pouvez-vous trouver ce motif de carrelage ?",
-        "alternateText": "Un motif de carrelage décoratif avec des dessins géométriques"
-      },
-      "tqvatszvgw": {
-        "answer": {
-          "answer": "À SEA Pop Culture, Pike and Pine, et chalo&co"
-        },
-        "clue": "Où pouvez-vous acheter un animal en peluche ?"
-      },
       "pB53_yVOPQ": {
         "answer": {
           "details": "Les salons sont :\n\n* Delta (A11)\n* Delta One (A11)\n* The Club (A11)\n* United (A10)\n* Delta (A1)\n* American Express Centurion (Terminal Central)\n* Alaska (C16)\n* Alaska (D1)\n* Alaska (mezzanine au-dessus de N13-N18)\n* The Club (au-dessus de S10)\n* British Airways (au-dessus de S10)."
         },
         "clue": "Prenez une photo devant l'entrée de chaque salon d'aéroport.",
         "hint": "Il y a onze salons à SEA, avec dix entrées."
+      },
+      "pngb9scdvn": {
+        "alternateText": "Un motif de carrelage décoratif avec des dessins géométriques",
+        "answer": {
+          "answer": "Au restaurant Lil' Woody's."
+        },
+        "clue": "Où pouvez-vous trouver ce motif de carrelage ?"
       },
       "qsWmZtJQx9": {
         "clue": "Cherchez dans les écrans des portes et prenez une photo du numéro de vol le plus élevé que vous repérez."
@@ -284,6 +270,12 @@
           "answer": "Japan Airlines (JAL) et Qatar Airways"
         },
         "clue": "Quelles compagnies aériennes accordent aux passagers de classe affaires l'accès aux salons The Club et British Airways Terraces ?"
+      },
+      "tqvatszvgw": {
+        "answer": {
+          "answer": "À SEA Pop Culture, Pike and Pine, et chalo&co"
+        },
+        "clue": "Où pouvez-vous acheter un animal en peluche ?"
       },
       "uaPC_HvMqd": {
         "clue": "Prenez une photo de quelque chose avec la Space Needle dessus."
@@ -321,6 +313,13 @@
           "answer": "+1-800-TBD-9999 (à vérifier)"
         },
         "clue": "Trouvez le bureau CBP dans le Concourse A. Quel est le numéro de téléphone affiché à l'extérieur ?"
+      },
+      "x7mtgkrj6s": {
+        "answer": {
+          "answer": "Bronze",
+          "details": "[\"Blackleaf\"](https://www.portseattle.org/page/blackleaf-deborah-butterfield) mesure sept pieds de haut et fait partie de la collection d'œuvres en bronze coulé de Butterfield et représente un cheval debout."
+        },
+        "clue": "Trouvez la statue \"Blackleaf\" de Deborah Butterfield. De quoi est-elle faite ?"
       },
       "xH4xrNHYJe": {
         "answer": {

--- a/src/components/image-answer.tsx
+++ b/src/components/image-answer.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useIsMobile } from "@/hooks/use-mobile";
 import { usePersistentAnswer } from "@/hooks/use-persistent-answer";
 import { isImageAnswer } from "@/types/answer";
 import { Clue } from "@/types/clue";
-import { CameraIcon, FileIcon, TrashIcon } from "lucide-react";
+import { FileIcon, TrashIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { useEffect, useMemo, useRef } from "react";
@@ -26,7 +25,6 @@ export function ImageAnswer({ clue }: ImageAnswerProperties) {
   const cameraInputReference = useRef<HTMLInputElement>(null);
   const galleryInputReference = useRef<HTMLInputElement>(null);
   const t = useTranslations("components");
-  const isMobile = useIsMobile();
 
   // Create object URLs when files change
   const objectUrls = useMemo(
@@ -61,17 +59,6 @@ export function ImageAnswer({ clue }: ImageAnswerProperties) {
 
   return (
     <div className="mt-2">
-      {/* Camera-only input (single image, hints to open camera) */}
-      <input
-        ref={cameraInputReference}
-        id={`${id}-camera`}
-        type="file"
-        accept="image/*"
-        onChange={handleFilesSelected}
-        capture="environment"
-        className="hidden"
-      />
-
       {/* Gallery input (can allow multiple selection) */}
       <input
         ref={galleryInputReference}
@@ -83,31 +70,17 @@ export function ImageAnswer({ clue }: ImageAnswerProperties) {
         className="hidden"
       />
 
-      <div className="flex items-center gap-2">
-        {isMobile && (
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={() => cameraInputReference.current?.click()}
-          >
-            <CameraIcon className="mr-2 h-4 w-4" aria-hidden />
-            {t("image-answer.take-photo-button")}
-          </Button>
-        )}
-
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          onClick={() => galleryInputReference.current?.click()}
-        >
-          <FileIcon className="mr-2 h-4 w-4" aria-hidden />
-          {t("image-answer.choose-files-button", {
-            expectedImageCount: expectedImageCount,
-          })}
-        </Button>
-      </div>
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={() => galleryInputReference.current?.click()}
+      >
+        <FileIcon className="mr-2 h-4 w-4" aria-hidden />
+        {t("image-answer.choose-files-button", {
+          expectedImageCount: expectedImageCount,
+        })}
+      </Button>
 
       {files.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-2">

--- a/src/components/image-answer.tsx
+++ b/src/components/image-answer.tsx
@@ -22,7 +22,6 @@ export function ImageAnswer({ clue }: ImageAnswerProperties) {
 
   const { expectedImageCount } = clue.answer;
   const [files, setFiles, loaded] = usePersistentAnswer<File[]>(id, []);
-  const cameraInputReference = useRef<HTMLInputElement>(null);
   const galleryInputReference = useRef<HTMLInputElement>(null);
   const t = useTranslations("components");
 


### PR DESCRIPTION
Fixes #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified image upload UI to a single "Choose files" button.
  * Removed in-app camera capture option on mobile; image selection now uses the device’s gallery/file picker.
  * Image previews and delete actions remain unchanged.

* **Chores**
  * Removed unused mobile camera text/string.
  * Reorganized and updated multiple post-security-page clues across locales (additions, replacements, hints, and accessibility alt text).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->